### PR TITLE
Open AIR Mini: Implemented Disconnected Mode 

### DIFF
--- a/Open Air Mini/Software/.gitignore
+++ b/Open Air Mini/Software/.gitignore
@@ -1,0 +1,5 @@
+# Gitignore settings for ESPHome
+# This is an example and may include too much for your use-case.
+# You can modify this file to suit your needs.
+/.esphome/
+/secrets.yaml

--- a/Open Air Mini/Software/README.md
+++ b/Open Air Mini/Software/README.md
@@ -2,54 +2,75 @@
 
 Visit https://esphome.io/ for instructions on how to deploy this firmware.
 
-More documentation might come available in future updates. Make sure to copy `example.secrets.yaml` to `secrets.yaml` and fill it with your own wifi credentials.
+More documentation might come available in future updates. 
 
-### Sensor 1/2
-Depending on what sensor is connected to what connector you need to declare the uart/I2C bus.
-```
+## Before you begin
+
+Make sure to copy `example.secrets.yaml` to `secrets.yaml` and fill it with your own WiFi credentials.
+
+## Different communication busses
+Depending on what sensor is connected to what connector you need to declare the uart and/or I<sup>2</sup>C busses. If using one sensor, only one (uart/I<sup>2</sup>C) bus is required. In some cases, multiple busses are required for using multiple sensors with the same hardware id (for I<sup>2</sup>C) or if they do not support a hardware id (for uart).
+
+For example, for uart:
+```C++
 #choose between:
-uart_id: uart_sensor_1 //used for Co2 Sensor only
-uart_id: uart_sensor_2 //used for Co2 Sensor only
+uart_id: uart_sensor_1 // Only used for the Senseair S8 CO2 sensor
+uart_id: uart_sensor_2 // Only used for the Senseair S8 CO2 sensor
+```
 
-and/or:
-i2c_id: i2c_sensor_1 //used for RH Sensor only
-i2c_id: i2c_sensor_2 //used for RH Sensor only
+
+For example, for I<sup>2</sup>C
+```C++
+i2c_id: i2c_sensor_1 // Used for RH sensors
+i2c_id: i2c_sensor_2 // Used for RH sensors
 ```
 Example:
-```
+```yaml
 sensor:
   - platform: sht3xd
-    #add sensor I2C bus here
+    i2c_id: i2c_sensor_1
     temperature:
       name: "Temperature Open AIR Mini x"
+      id: air_temperature
     humidity:
       name: "Humidity Open AIR Mini x"
+      id: air_humidity
     address: 0x44
     update_interval: 60s
 
 #or
 sensor:
   - platform: senseair
-    #add sensor UART bus here
+    uart_id: uart_sensor_1
     co2:
-      name: "Co2 Open AIR Mini x"
+      name: "CO2 Open AIR Mini x"
     update_interval: 60s
 ```
+
+## Sensors
+
+The following sensors are supported right away, either via ESPHome or via a custom implementation.
+
+1. [SHT-31](#sensor-support-sht-31)
+1. [Senseair S8](#sensor-support-senseair-s8)
+1. [SHT-20](#sensor-support-sht-20)
 
 ### Sensor Support: SHT-31
 
 More info about this sensor and ESPhome : https://esphome.io/components/sensor/sht3xd.html
 
-If you want to add a SHT-31 moisture & Temperature sensor to the Open AIR Mini. Add the following code at the bottom of `open-air-mini.yaml` 
+If you want to add a SHT-31 moisture & Temperature sensor to the Open AIR Mini, add the following code at the bottom of the `open-air-mini.yaml` file.
 
-```
+```yaml
 sensor:
   - platform: sht3xd
-  #add sensor I2C bus here
+    i2c_id: i2c_sensor_1
     temperature:
       name: "Temperature Open AIR Mini x"
+      id: air_temperature
     humidity:
       name: "Humidity Open AIR Mini x"
+      id: air_humdity
     address: 0x44
     update_interval: 60s
 ```
@@ -58,44 +79,23 @@ sensor:
 
 More info about this sensor and ESPhome : https://esphome.io/components/sensor/senseair.html?highlight=co2+senseair
 
-If you want to add a Senseair S8 Co2 sensor to the Open AIR Mini. Add the following code at the bottom of `open-air-mini.yaml` 
+If you want to add a Senseair S8 CO2 sensor to the Open AIR Mini, add the following code at the bottom of the `open-air-mini.yaml` file.
 
-```
+```yaml
 sensor:
   - platform: senseair
-  #add sensor I2C bus here
+    uart_id: uart_sensor_1
     co2:
-      name: "Co2 Open AIR Mini x"
+      name: "CO2 Open AIR Mini x"
     update_interval: 60s
 ```
 
-### Combination of Senseair S8 & SHT-31 in one Sensor
+### Sensor Support: SHT-20
+⚠️ The original temperature and humidity sensor can only be connected on sensor connector 1, thus using I<sup>2</sup>C bus 1 (which is implicitly used).
 
-If you have a combination sensor add the following to the bottom of `open-air-mini.yaml` 
+If you have a SHT-20 Sensor add the following code at the bottom of `open-air-mini.yaml`
 
-```
-sensor:
-  - platform: sht3xd
-    #add sensor I2C bus here
-    temperature:
-      name: "Temperature Open AIR Mini x"
-    humidity:
-      name: "Humidity Open AIR Mini x"
-    address: 0x44
-    update_interval: 60s
-  - platform: senseair
-    #add sensor UART bus here
-    co2:
-      name: "Co2 Open AIR Mini x"
-    update_interval: 60s
-```
-
-### SHT-20 Sensor
-! Warning ! the original Duco sensor can only be connected on sensor connector 1!
-
-If you have a SHT-20 Sensor add the following code at the bottom of `open-air-Mini.yaml` 
-
-```
+```yaml
 sensor:
   - platform: custom
     lambda: |-
@@ -104,34 +104,80 @@ sensor:
       return {sht20->temperature_sensor, sht20->humidity_sensor, sht20->vpd_sensor, sht20->dew_point_sensor};
     sensors:
       - name: "Temperature Open AIR Mini x"
-        id: sensor_temperature
+        id: air_temperature
         unit_of_measurement: °C
         accuracy_decimals: 2
       - name: "Humidity Open AIR Mini x"
-        id: sensor_humidity
+        id: air_humidity
         unit_of_measurement: "%"
         accuracy_decimals: 2
       - name: "Open AIR Mini x Vapour-pressure deficit"
-        id: sensor_vpd
+        id: air_vapor_pressure_deficit
         unit_of_measurement: "kPa"
         accuracy_decimals: 2
       - name: "Open AIR Mini x Dew point"
-        id: sensor_dew_point
+        id: air_dew_point
         unit_of_measurement: °C
         accuracy_decimals: 2
 
 ```
+
 Add the following righ below "board: esp32dev" 
-```
+```yaml
   libraries:
     - Wire
     - u-fire/uFire SHT20@^1.1.1
   includes: sht20.h
 ```
 
-Place the SHT20.H file in the same directory as the `open-air-Mini.yaml`.
-Thanks 
+Place the SHT20.H file in the same directory as the `open-air-mini.yaml`.
 
 @[wre](https://github.com/wrenoud) Thanks for your support on this sensor implementation
 
-Change all the 'x' in the document for a number or a letter so you know which sensor is which. (if sensors have identical names they wont show up in HA)
+### Using the Combination Sensor with Senseair S8 & SHT-31 on the same board
+
+If you want to use this specific combination sensor, add the following to the bottom of the `open-air-mini.yaml` file.
+
+```yaml
+sensor:
+  - platform: sht3xd
+    i2c_id: i2c_sensor_1
+    temperature:
+      name: "Temperature Open AIR Mini x"
+      id: air_temperature
+    humidity:
+      name: "Humidity Open AIR Mini x"
+      id: air_humidity
+    address: 0x44
+    update_interval: 60s
+  - platform: senseair
+    uart_id: uart_sensor_1
+    co2:
+      name: "CO2 Open AIR Mini x"
+      id: air_co2
+    update_interval: 60s
+```
+
+###  Notes on using multiple sensors
+
+Change all the 'x' in the document to a number or a letter if you are using multiple sensors and want to be able to clearly identify which is which, and also to prevent conflicts in id namings. If sensors have identical names they wont show up in HA.
+
+## Disconnected Mode
+
+When Home Assistant cannot be reached, either because of a lack of WiFi connection or the Home Assistant server being unavailable, a `disconnected mode` has been added to provide basic functionality to the Open AIR Mini unit. This mode will allow the unit to continue standalone, which in combination with a humidity sensor even allows for different fan speeds activated by humidity levels.
+
+### Disconnected Mode without Humidity Sensor
+
+When the humidity sensor is not connected, the disconnected mode will only allow for the fan to run at a constant speed.
+
+The fan speed can be set in the `open-air-mini.yaml` file by changing the global variable `disconnected_default_fan_speed` to a value between 0 and 100.
+
+To use the Open AIR Mini in disconnected mode without a humidity sensor, in the `open-air-mini.yaml` file, make sure to use the `!include disconnected-mode-without-humidity-sensor.yaml` line in the `script` section. Make sure that the other include is commented out.
+
+### Disconnected Mode With Humidity Sensor
+
+When the humidity sensor is connected, the disconnected mode will allow for the fan to run at a variable speed based on the humidity level.
+
+The different fan speeds and thresholds can be set in the `open-air-mini.yaml` file by changing the global variables that correspond to the different fan speeds and humidity thresholds (see inline comments).
+
+To use the Open AIR Mini in disconnected mode with a humidity sensor, such a sensor has to be configured in the `open-air-mini.yaml`, and in the `script` section, make sure to use the `!include disconnected-mode-with-humidity-sensor.yaml` line. Make sure that the other include is commented out. The humidity sensor has to be connected to the Open AIR Mini, and the `id` of the humidity sensor has to be `air_humidity`.

--- a/Open Air Mini/Software/disconnected-mode-with-humidity.yaml
+++ b/Open Air Mini/Software/disconnected-mode-with-humidity.yaml
@@ -1,0 +1,17 @@
+---
+- id: disconnected_mode
+  mode: single
+  then:
+    - logger.log: "Disconnected Mode Triggered"
+    - fan.turn_on: 
+        id: fan_motor
+        speed: !lambda |-
+          auto hum = id(air_humidity).state;
+          if (hum >= id(disconnected_hum_level_max_speed)) {
+            return id(disconnected_max_fan_speed);
+          } else if (hum >= id(disconnected_hum_level_medium_speed)) {
+            return id(disconnected_medium_fan_speed);
+          } else {
+            return id(disconnected_default_fan_speed);
+          }
+          return id(disconnected_default_fan_speed);

--- a/Open Air Mini/Software/disconnected-mode-without-humidity.yaml
+++ b/Open Air Mini/Software/disconnected-mode-without-humidity.yaml
@@ -1,0 +1,9 @@
+---
+- id: disconnected_mode
+  mode: single
+  then:
+    - logger.log: "Disconnected Mode Triggered"
+    - fan.turn_on: 
+        id: fan_motor
+        speed: !lambda |-
+          return id(disconnected_default_fan_speed);

--- a/Open Air Mini/Software/open-air-mini.yaml
+++ b/Open Air Mini/Software/open-air-mini.yaml
@@ -28,6 +28,35 @@ wifi:
 
 captive_portal:
 
+globals:
+  # Disconnected Mode Max Fan Speed, linked to Disconnected Hum Level Max Speed
+  - id: disconnected_max_fan_speed
+    type: int
+    restore_value: no
+    initial_value: "100"
+  # Disconnected Mode Medium Fan Speed, linked to Disconnected Hum Level Medium Speed
+  - id: disconnected_medium_fan_speed
+    type: int
+    restore_value: no
+    initial_value: "60"
+  # Disconnected Mode Default Fan Speed, for humidities lower than Disconnected Hum Level Medium Speed
+  # or if NOT using a humidity sensor. Without sensor this speed will be maintained untill a connection
+  # to Home Assistant has been restored and your automations can take over.
+  - id: disconnected_default_fan_speed
+    type: int
+    restore_value: no
+    initial_value: "25"
+  # Disconnected Mode Max Fan Speed Threshold    
+  - id: disconnected_hum_level_max_speed
+    type: int
+    restore_value: no
+    initial_value: "75"
+  # Disconnected Mode Medium Fan Speed Threshold
+  - id: disconnected_hum_level_medium_speed
+    type: int
+    restore_value: no
+    initial_value: "55"
+
 #
 uart:
 #UART For Sensor 1
@@ -71,9 +100,30 @@ fan:
   - platform: speed
     output: open_air_mini
     name: "Open AIR Mini"
+    id: fan_motor
     
 sensor: 
   - platform: pulse_counter
     pin: GPIO14
     unit_of_measurement: 'RPM'
     name: 'AIR Mini RPM'
+
+script:
+  # Below includes for disconnected mode are mutually exclusive. Only use one at a time!
+  !include disconnected-mode-without-humidity.yaml
+  # !include disconnected-mode-with-humidity.yaml
+
+interval:
+  - interval: 30s
+    then:
+      - logger.log: "API Connectivity Check for Disconnected Mode"
+      - if:
+          condition:
+            not:
+              api.connected:
+          then:
+            - logger.log: "API disconnected"
+            - script.execute: disconnected_mode
+          else:
+            - logger.log: "API connected"
+            - script.stop: disconnected_mode


### PR DESCRIPTION
For using the Open AIR Mini in standalone mode, a disconnected mode has been implemented that can be used with and without a humidity sensor. See the README.md file for more information.