### PR TITLE
Add RPM id to avoid non unique id error message (in open-air-mini.yaml)

### DIFF
--- a/Open Air Mini/Software/open-air-mini.yaml
+++ b/Open Air Mini/Software/open-air-mini.yaml
@@ -107,6 +107,7 @@ sensor:
     pin: GPIO14
     unit_of_measurement: 'RPM'
     name: 'AIR Mini RPM'
+    id: open_air_mini_rpm
 
 script:
   # Below includes for disconnected mode are mutually exclusive. Only use one at a time!


### PR DESCRIPTION
+id: open_air_mini_rpm