### PR TITLE
fix: sensor scd4x config

### DIFF
--- a/Open AIR Valve/Software/README.md
+++ b/Open AIR Valve/Software/README.md
@@ -75,6 +75,7 @@ If you want to add a SCD-40 moisture & Temperature sensor & Co2 sensor to the Op
 sensor:
   - platform: scd4x
     i2c_id: i2c_sensor_1 
+    co2:
       name: "Open AIR Valve x CO2"
       id: air_Co2
       accuracy_decimals: 0
@@ -122,6 +123,7 @@ If you want to add a SGP-41 VOC & NOx to the Open AIR Mini, add the following co
 sensor:
   - platform: scd4x
     i2c_id: i2c_sensor_1 
+    co2:
       name: "Open AIR Mini Sensor Valve x CO2"
       id: air_Co2
       accuracy_decimals: 0

--- a/Open Air Mini/Software/README.md
+++ b/Open Air Mini/Software/README.md
@@ -101,6 +101,7 @@ If you want to add a SCD-40 moisture & Temperature sensor & Co2 sensor to the Op
 sensor:
   - platform: scd4x
     i2c_id: i2c_sensor_1 
+    co2:
       name: "Open AIR Mini x CO2"
       id: air_Co2
       accuracy_decimals: 0
@@ -147,7 +148,8 @@ If you want to add a SGP-41 VOC & NOx to the Open AIR Mini, add the following co
 ```yaml
 sensor:
   - platform: scd4x
-    i2c_id: i2c_sensor_1 
+    i2c_id: i2c_sensor_1
+    co2:
       name: "Open AIR Mini Sensor Mini x CO2"
       id: air_Co2
       accuracy_decimals: 0


### PR DESCRIPTION
- missing `co2`, creating invalid yaml