### PR TITLE
Add platform for `ota:` (ESPHome 2024.6)

### DIFF
--- a/Open AIR Mini/Software/open-air-mini.yaml
+++ b/Open AIR Mini/Software/open-air-mini.yaml
@@ -15,6 +15,7 @@ web_server:
 api:
 
 ota:
+  platform: esphome
   password: "9f2ab9aa715f573e2476e75a5ec7f4e7"
 
 wifi:

--- a/Open AIR Valve/Software/open-air-valve.yaml
+++ b/Open AIR Valve/Software/open-air-valve.yaml
@@ -74,6 +74,7 @@ api:
           target: !lambda 'return target;'
 
 ota:
+  platform: esphome
   password: "9f2ab9aa715f573e2476e75a5ec7f4e7"
 
 wifi:


### PR DESCRIPTION
ESPHome had a breaking change in version 2024.6, where the `ota:` integration now needs a mandatory `platform` key. This PR adds those mandatory keys.

More info: https://esphome.io/changelog/2024.6.0.html#ota-platforms