### PR TITLE
Drop ota update password

### DIFF
--- a/Open AIR Mini/Software/open-air-mini.yaml
+++ b/Open AIR Mini/Software/open-air-mini.yaml
@@ -15,7 +15,6 @@ web_server:
 api:
 
 ota:
-  password: "9f2ab9aa715f573e2476e75a5ec7f4e7"
 
 wifi:
   ssid: !secret wifi_ssid

--- a/Open AIR Valve/Software/open-air-valve.yaml
+++ b/Open AIR Valve/Software/open-air-valve.yaml
@@ -74,7 +74,6 @@ api:
           target: !lambda 'return target;'
 
 ota:
-  password: "9f2ab9aa715f573e2476e75a5ec7f4e7"
 
 wifi:
   ssid: !secret wifi_ssid


### PR DESCRIPTION
Suggest to drop the pre-configured OTA password, as users should set the password themselves if they feel it is applicable for their environment. 

Above all, users should _never_ use this pre-configured password as this is out-in-the-open on GitHub: that means it is as good as having no password at all. 

Also, some users (at GoT) did not even realize a password was set and had troubles dropping it from their config. 